### PR TITLE
Update documentation to use run.py as main entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ python3 create_indexes.py
 ### Development
 ```bash
 # Simple development server
-python3 mongo.py
+python3 run.py
 
 # Or with environment variables loaded
 python3 -m flask run --debug
@@ -170,7 +170,8 @@ chosytable/
 │   └── templates/          # Jinja2 templates
 ├── create_indexes.py        # Database optimization script
 ├── setup_optimizations.py  # Automated setup wizard
-├── mongo.py                # Application entry point
+├── run.py                  # Application entry point
+├── mongo.py                # Legacy entry point
 ├── requirements.txt        # Python dependencies
 ├── .env.template          # Environment configuration template
 ├── OPTIMIZATION_GUIDE.md  # Detailed optimization documentation

--- a/run.py
+++ b/run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""
+Simple entry point for the Flask application.
+Run with: python3 run.py
+"""
+
+from app import app
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
- Updated development server instructions to use 'python3 run.py'
- Added run.py as main application entry point in project structure
- Marked mongo.py as legacy entry point for clarity